### PR TITLE
Allow click version bump 

### DIFF
--- a/pytestgen/load.py
+++ b/pytestgen/load.py
@@ -23,7 +23,7 @@ class PyTestGenInputFile:
     """
     def __init__(self, name: str, file_path: str) -> None:
         self.name = name
-        self.path = file_path
+        self.path = path.normpath(file_path)
         self.full_path = path.join(file_path, name)
 
     def get_module(self) -> str:

--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,6 @@ setup(
     keywords="testing test generation pytest",
     packages=find_packages(exclude=["tests"]),
     python_requires=">=3.7",
-    install_requires=["click>=8.0", "jinja2==2.11.3", "markupsafe==1.1.1"],
-    entry_points={
-        "console_scripts": ["pytestgen=pytestgen.cli.pytestgen:cli"]
-    },
+    install_requires=["click>=8.0", "jinja2>=3.0.0", "markupsafe>=1.1.1"],
+    entry_points={"console_scripts": ["pytestgen=pytestgen.cli.pytestgen:cli"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     keywords="testing test generation pytest",
     packages=find_packages(exclude=["tests"]),
     python_requires=">=3.7",
-    install_requires=["click==7.0", "jinja2==2.11.0", "markupsafe==1.1.1"],
+    install_requires=["click>=8.0", "jinja2==2.11.3", "markupsafe==1.1.1"],
     entry_points={
         "console_scripts": ["pytestgen=pytestgen.cli.pytestgen:cli"]
     },

--- a/tests/pytestgen/test_load.py
+++ b/tests/pytestgen/test_load.py
@@ -1,5 +1,5 @@
 from contextlib import nullcontext as does_not_raise
-from os.path import sep
+from os.path import normpath, sep
 
 import pytest
 import pyfakefs
@@ -26,11 +26,15 @@ def test_directory(fs):
 
 @pytest.mark.parametrize(
     "file,expected,raises",
-    [("/dir/a_file.py",
-      PyTestGenInputSet(
-          "output",
-          [PyTestGenInputFile("a_file.py", f"{sep}dir")]), does_not_raise()),
-     ("txt_file.txt", None, pytest.raises(ValueError))])
+    [
+        (
+            normpath("/dir/a_file.py"),
+            PyTestGenInputSet("output", [PyTestGenInputFile("a_file.py", f"{sep}dir")]),
+            does_not_raise(),
+        ),
+        ("txt_file.txt", None, pytest.raises(ValueError)),
+    ],
+)
 def test_filename(fs, file, expected, raises):
     fs.create_file("/dir/a_file.py")
 


### PR DESCRIPTION
Hi,
I made some changes that seem to work in my windows env, but I guess the CI gatekeepers will decide on that!

Changes are:
- Allow more recent versions of the click package. I came across this trying to run pytestgen with azure functions, and they had a click clash.
- Update the tests so that they'd run on windows. Nothing very exciting here, just a tiny bit of `normpath` magic to make sure that paths entered as strings are consistent when the test asserts that they are. 
- Bump the jinja2 version in line with one of the dependabot PRs. 